### PR TITLE
Add SNS alerting when the Ophan AWS account is sending a dangerous number of bouncing emails

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "log4j-over-slf4j" % "1.7.28", //  log4j-over-slf4j provides `org.apache.log4j.MDC`, which is dynamically loaded by the Lambda runtime
   "ch.qos.logback" % "logback-classic" % "1.2.3",
 
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.632",
+  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.642",
+  "com.amazonaws" % "aws-java-sdk-sns" % "1.11.642",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9.3", // So many Snyk warnings
   "com.typesafe.play" %% "play-json" % "2.7.4",
   "org.scanamo" %% "scanamo" % "1.0.0-M11",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -8,6 +8,7 @@ Parameters:
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
+    DependsOn: PermanentEmailBounceTopic
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -40,22 +41,37 @@ Resources:
               Resource:
                 - "arn:aws:dynamodb:eu-west-1:021353022223:table/ophan-alerts"
                 - "arn:aws:dynamodb:eu-west-1:021353022223:table/DEV-ophan-alerts"
+            Statement:
+              Effect: Allow
+              Action:
+                - sns:Publish
+              Resource: !Ref PermanentEmailBounceTopic
   BounceSNSTopic:
     Type: "AWS::SNS::Topic"
     DependsOn: Lambda
     Properties:
-      DisplayName: Housekeeping SNS topic to alert when AWS SES emails bounce from Ophan Dashboard alerts
+      DisplayName: SNS topic alerted when AWS SES emails bounce (eg from Ophan Dashboard alerts, or Airflow)
       Subscription:
         - Protocol: lambda
           Endpoint: !GetAtt Lambda.Arn
       TopicName: ses-email-bounce-notifications-for-housekeeper
+
+  PermanentEmailBounceTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: Threat to email-sending ability of Ophan's AWS account
+
   Lambda:
     Type: AWS::Lambda::Function
+    DependsOn: PermanentEmailBounceTopic
     Properties:
       Code:
         S3Bucket: ophan-dist
         S3Key: ophan/PROD/housekeeper/housekeeper.jar
       Description: Housekeeping for Ophan
+      Environment:
+        Variables:
+          PermanentEmailBounceTopicArn: !Ref PermanentEmailBounceTopic
       Handler: housekeeper.Lambda::handler
       MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn

--- a/src/main/scala/housekeeper/AWS.scala
+++ b/src/main/scala/housekeeper/AWS.scala
@@ -1,0 +1,18 @@
+package housekeeper
+
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EC2ContainerCredentialsProviderWrapper}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions.EU_WEST_1
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.sns.AmazonSNSAsyncClient
+
+object AWS {
+  val credentials = new AWSCredentialsProviderChain(
+    new EC2ContainerCredentialsProviderWrapper,
+    new ProfileCredentialsProvider("ophan")
+  )
+
+  val SNS = AmazonSNSAsyncClient.asyncBuilder().withCredentials(credentials).withRegion(EU_WEST_1).build()
+
+  val Dynamo = AmazonDynamoDBAsyncClient.asyncBuilder().withCredentials(credentials).withRegion(EU_WEST_1).build()
+}

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -1,8 +1,6 @@
 package housekeeper
 
 import cats.implicits._
-import com.amazonaws.regions.Regions.EU_WEST_1
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import housekeeper.Dynamo.OphanAlert
 import org.scanamo._
 import org.scanamo.syntax._
@@ -10,7 +8,7 @@ import org.scanamo.auto._
 
 object Dynamo extends Logging {
 
-  val scanamo = Scanamo(AmazonDynamoDBAsyncClient.asyncBuilder().withRegion(EU_WEST_1).build())
+  val scanamo = Scanamo(AWS.Dynamo)
 
   case class OphanAlert(
                          email: String,


### PR DESCRIPTION
The AWS SNS topic provided by AWS SES to notify us about bounces is FAR TOO NOISY, it tells us about all bounces, even transient ones (when a user goes on holiday and sets auto-respond), so it's very hard to see when problems arise.

This change creates a [new SNS topic](https://eu-west-1.console.aws.amazon.com/sns/v3/home?region=eu-west-1#/topic/arn:aws:sns:eu-west-1:021353022223:Ophan-Housekeeper-PermanentEmailBounceTopic-13TE98BK31YQJ) which we will only publish to when emails are bouncing 'permanently' and have in fact been 'suppressed' by AWS SES for failing too many times. We can now safely subscribe the Ophan Dev and Data Tech teams to this SNS topic without fear of bombardment.

https://groups.google.com/a/guardian.co.uk/d/msg/ophan.dev/Ckk1wcDjksA/0ZRwGfcSAgAJ

