### PR TITLE
Snyk reported Jackson-databind vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
 
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.642",
   "com.amazonaws" % "aws-java-sdk-sns" % "1.11.642",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9.3", // So many Snyk warnings
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0.pr3", // So many Snyk warnings
   "com.typesafe.play" %% "play-json" % "2.7.4",
   "org.scanamo" %% "scanamo" % "1.0.0-M11",
   "org.scanamo" %% "scanamo-testkit" % "1.0.0-M11" % "test",


### PR DESCRIPTION
Updated the Jackson databind version in order to fix vulnerabilities
identified by Snyk.

Vulnerabilities were fixed with a single version change. 