### PR TITLE
Fix bug loading AWS credentials that stopped alert-deletion & SNS

### DIFF
--- a/src/main/scala/housekeeper/AWS.scala
+++ b/src/main/scala/housekeeper/AWS.scala
@@ -1,14 +1,14 @@
 package housekeeper
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, EC2ContainerCredentialsProviderWrapper}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider}
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.sns.AmazonSNSAsyncClient
 
 object AWS {
   val credentials = new AWSCredentialsProviderChain(
-    new EC2ContainerCredentialsProviderWrapper,
+    new EnvironmentVariableCredentialsProvider,
     new ProfileCredentialsProvider("ophan")
   )
 


### PR DESCRIPTION
AWS placed our SES account under review (giving us notice that they could **block our ability to send email** :email: :skull: ) on [Saturday 15th February](https://groups.google.com/a/guardian.co.uk/d/msg/aws-ophan/F880jhVL2yY/Wz_iVkkZAQAJ):

> Your current bounce rate is 10.63%. We measured this rate over the last
> 10,028 eligible emails* you sent. Our analysis covers the last 4.3 days.

![image](https://user-images.githubusercontent.com/52038/74613611-d0ec7600-5107-11ea-8ba5-388de345674e.png)
_https://logs.gutools.co.uk/s/ophan/goto/74968773d968bb5f2b8f285bd3354002_

This was due to AWS-credential-loading in the Ophan Housekeeper lambda being broken by commit 31cec53c65 back in [October 2019](https://github.com/guardian/ophan-housekeeper/pull/5/files#r379906348) - with credential-loading broken, the lambda couldn't load the AWS credentials it needed to delete entries from the [`ophan-alerts`](https://eu-west-1.console.aws.amazon.com/dynamodb/home?region=eu-west-1&state=hashArgs%23#tables:selected=ophan-alerts;tab=items) DynamoDB table, or post to the [SNS topic](https://eu-west-1.console.aws.amazon.com/sns/v3/home?region=eu-west-1#/topic/arn:aws:sns:eu-west-1:021353022223:Ophan-Housekeeper-PermanentEmailBounceTopic-13TE98BK31YQJ).

Perhaps surprisingly, the Ophan Housekeeper lambda _only_ needs those AWS credentials when it's dealing with a permanently bouncing email - so there was no obvious problem until a permanent bounce occurred, starting at [13:26 on February 12th 2020](https://logs.gutools.co.uk/s/ophan/app/kibana#/doc/581f7b00-c4df-11e9-bc08-9d1af4d9c1d5/logstash-ophan-2020.02.12?id=ciyUOXABBviLcZqRrCAI&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2020-02-12T13:26:31.042Z',to:'2020-02-12T13:26:40.791Z'))):

```
Unable to load AWS credentials from any provider in the chain: [com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@1e730495: Unable to load credentials from service endpoint, com.amazonaws.auth.profile.ProfileCredentialsProvider@7d3a22a9: profile file cannot be null]: com.amazonaws.SdkClientException
com.amazonaws.SdkClientException: Unable to load AWS credentials from any provider in the chain: [com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@1e730495: Unable to load credentials from service endpoint, com.amazonaws.auth.profile.ProfileCredentialsProvider@7d3a22a9: profile file cannot be null]
	at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:136)
...
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.doInvoke(AmazonDynamoDBClient.java:4805)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.invoke(AmazonDynamoDBClient.java:4772)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.executeQuery(AmazonDynamoDBClient.java:2641)
	at com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient.query(AmazonDynamoDBClient.java:2607)
	at org.scanamo.ops.ScanamoSyncInterpreter.apply(ScanamoSyncInterpreter.scala:35)
```

As the lambda was broken, it wasn't able to decommission the relevant Ophan Alerts - so Trigr kept on sending them, and there were so many of them, bouncing permanently, that AWS placed our SES account under review.

## What next?

Once this fix has been merged, it should hopefully resolve the issue - but **note that AWS wants us to follow up with them** and let them know what we've done before they take us out of review:

> Finally, contact us with answers to the following questions:
> * What caused your high bounce rate?
> * What changes have you made in your email-sending systems or processes?
> * How do these changes ensure that the issue won't occur again in the future?
> We'll evaluate your responses to these questions. If we agree that your changes address this issue, we'll reset the metrics for your account, and end your review period or restore your account's ability to send email.