### PR TITLE
Add GitHub Action config for Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,33 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run Snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=guardian-ophan --project-name=${{ github.repository }}
+          command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
This sets up a Snyk test on GitHub Actions as part of security pairing, using this PR as a model: https://github.com/guardian/ophan/pull/4141. As covered [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/snyk.md#integrating-snyk-with-your-projects), this approach is best practice.

It fails succesfully on this branch (before updating the PR to apply only to main)!

![image](https://user-images.githubusercontent.com/11380557/129734929-e959044e-e833-49f4-ae45-490002934d2d.png)

This will not lead to big red crosses on every PR, because as @ripecosta put it [when we did this in Ophan proper](https://github.com/guardian/ophan/pull/4141):

> snyk monitor will always return successfully if it manages to report to snyk.io, whether there are vulnerabilities present or not. Only snyk test (previously being run on non-main branches) returns a failure if it detects a vulnerability.

Because we are setting the command to monitor we're covered by this.

- [ ] Check that vulnerabilities are being reported in snyk.io dashboard post-merge
- [ ] Follow up by deleting the old config in Snyk