### PR TITLE
Upgrade to sbt v1.5.7 and compact buildinfo setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,11 +59,11 @@ inConfig(Test)(Seq(
 
 
 buildInfoPackage := "housekeeper"
-buildInfoKeys := Seq[BuildInfoKey](
-  "buildNumber" -> Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV"),
-  // so this next one is constant to avoid it always recompiling on dev machines.
-  // we only really care about build time on teamcity, when a constant based on when
-  // it was loaded is just fine
-  "buildTime" -> System.currentTimeMillis,
-  "gitCommitId"-> Option(System.getenv("BUILD_VCS_NUMBER")).getOrElse("DEV")
-)
+buildInfoKeys := {
+  val buildInfo = com.gu.riffraff.artifact.BuildInfo(baseDirectory.value)
+  Seq[BuildInfoKey](
+    "buildNumber" -> buildInfo.buildIdentifier,
+    "gitCommitId" -> buildInfo.revision,
+    "buildTime" -> System.currentTimeMillis
+  )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7


### PR DESCRIPTION
https://github.com/sbt/sbt/releases/tag/v1.5.7 updates log4j 2 to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability (CVE-2021-45046).

I've also stuck a small tweak to the buildinfo settings in, taking advantage of guardian/sbt-riffraff-artifact#33 .

This is a close twin of the changes in https://github.com/guardian/ophan-geoip-db-refresher/pull/12 !
