### PR TITLE
Upgrade scanamo and aws versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,23 +15,21 @@ scalacOptions ++= Seq(
   "-Ywarn-dead-code"
 )
 
-val awsSdkVersion = "1.12.156"
+val scanamoVersion = "1.0.0-M23"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1",
   "org.slf4j" % "log4j-over-slf4j" % "1.7.32", //  log4j-over-slf4j provides `org.apache.log4j.MDC`, which is dynamically loaded by the Lambda runtime
-  "ch.qos.logback" % "logback-classic" % "1.2.10",
 
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.10",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1", // So many Snyk warnings
-  "com.typesafe.play" %% "play-json" % "2.9.2",
-  "org.scanamo" %% "scanamo" % "1.0.0-M11",
-  "org.scanamo" %% "scanamo-testkit" % "1.0.0-M11" % Test,
+  "com.typesafe.play" %% "play-json" % "2.10.0-RC7",
+  "org.scanamo" %% "scanamo" % scanamoVersion,
+  "org.scanamo" %% "scanamo-testkit" % scanamoVersion % Test,
   "org.scalatest" %% "scalatest" % "3.2.11" % Test
-)
+) ++ Seq("dynamodb", "sns", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.17.270")
 
 enablePlugins(RiffRaffArtifact, BuildInfoPlugin)
 

--- a/src/main/scala/housekeeper/AWS.scala
+++ b/src/main/scala/housekeeper/AWS.scala
@@ -1,6 +1,6 @@
 package housekeeper
 
-import software.amazon.awssdk.auth.credentials.*
+import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
 import software.amazon.awssdk.http.SdkHttpClient
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -17,7 +17,7 @@ object Dynamo extends Logging {
                          email: String,
                          alertName: String
                        ) {
-    val primaryKey = "email" -> email and "alertName" -> alertName
+    val primaryKey = "email" === email and "alertName" === alertName
   }
 }
 
@@ -29,12 +29,12 @@ class AlertDeletion(scanamo: ScanamoAsync, tableName: String) extends Logging {
     val baseContext = Map("alertsToDelete.emailAddress" -> email)
     logger.info(baseContext, s"About to search for alerts to delete for '$email'")
     scanamo.exec(for {
-      results <- table.query("email" -> email)
+      results <- table.query("email" === email)
       alertsForEmail = results.flatMap(_.toOption)
       _ = logger.info(baseContext ++ Map(
         "alertsToDelete.found.count" -> alertsForEmail.size,
       ), s"About to delete ${alertsForEmail.size} alerts for '$email'")
-      deletionResults <- alertsForEmail.traverse(alert => table.delete(alert.primaryKey))
+      _ <- alertsForEmail.traverse(alert => table.delete(alert.primaryKey))
     } yield {
       logger.info(baseContext, s"...successfully deleted ${alertsForEmail.size} alerts for '$email'")
     })

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -1,14 +1,15 @@
 package housekeeper
 
+import concurrent.ExecutionContext.Implicits.global
 import cats.implicits._
 import housekeeper.Dynamo.OphanAlert
 import org.scanamo._
 import org.scanamo.syntax._
-import org.scanamo.auto._
+import org.scanamo.generic.auto._
 
 object Dynamo extends Logging {
 
-  val scanamo = Scanamo(AWS.Dynamo)
+  val scanamo = ScanamoAsync(AWS.dynamoDb)
 
   case class OphanAlert(
                          email: String,

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -9,7 +9,7 @@ import org.scanamo.generic.auto._
 
 object Dynamo extends Logging {
 
-  val scanamo = ScanamoAsync(AWS.dynamoDb)
+  val scanamo: ScanamoAsync = ScanamoAsync(AWS.dynamoDb)
 
   case class OphanAlert(
                          email: String,
@@ -19,7 +19,7 @@ object Dynamo extends Logging {
   }
 }
 
-class AlertDeletion(scanamo: Scanamo, tableName: String) extends Logging {
+class AlertDeletion(scanamo: ScanamoAsync, tableName: String) extends Logging {
 
   val table = Table[OphanAlert](tableName)
 

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -7,6 +7,8 @@ import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 
+import scala.concurrent.Future
+
 object Dynamo extends Logging {
 
   val scanamo: ScanamoAsync = ScanamoAsync(AWS.dynamoDb)
@@ -23,7 +25,7 @@ class AlertDeletion(scanamo: ScanamoAsync, tableName: String) extends Logging {
 
   val table = Table[OphanAlert](tableName)
 
-  def deleteAllAlertsForEmailAddress(email: String): Unit = {
+  def deleteAllAlertsForEmailAddress(email: String): Future[Unit] = {
     val baseContext = Map("alertsToDelete.emailAddress" -> email)
     logger.info(baseContext, s"About to search for alerts to delete for '$email'")
     scanamo.exec(for {

--- a/src/main/scala/housekeeper/Lambda.scala
+++ b/src/main/scala/housekeeper/Lambda.scala
@@ -2,8 +2,8 @@ package housekeeper
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
-import com.amazonaws.services.sns.model.PublishRequest
 import play.api.libs.json.{JsError, JsSuccess, Json}
+import software.amazon.awssdk.services.sns.model.PublishRequest
 
 import scala.jdk.CollectionConverters._
 
@@ -31,7 +31,7 @@ object Lambda extends Logging {
       if (bounce.isOnSuppressionList) {
         val arn = sys.env("PermanentEmailBounceTopicArn")
         logger.info(s"Sending an SNS alert to $arn")
-        AWS.SNS.publishAsync(new PublishRequest(arn, bounceSummary))
+        AWS.SNS.publish(PublishRequest.builder().message(bounceSummary).topicArn(arn).build())
       }
     }
   }

--- a/src/main/scala/housekeeper/Lambda.scala
+++ b/src/main/scala/housekeeper/Lambda.scala
@@ -6,8 +6,10 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import software.amazon.awssdk.services.sns.model.PublishRequest
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 
 object Lambda extends Logging {
 
@@ -15,47 +17,42 @@ object Lambda extends Logging {
 
   def handleBounce(bounceNotification: BounceNotification): Future[_] = {
     val bounce = bounceNotification.bounce
-
-    val bouncedAddresses = bounce.bouncedEmailAddresses.toSeq.sorted
-
-    val senderOfBouncedEmail = bounceNotification.mail.source
-    val bounceSummary = s"$senderOfBouncedEmail sent a ${bounce.bounceType} bounced message to ${bouncedAddresses.mkString(",")}"
     logger.info(Map(
       "bounce.type" -> bounce.bounceType,
       "bounce.subtype" -> bounce.bounceSubType,
       "bounce.permanent" -> bounce.isPermanent,
-      "bounce.mail.source" -> senderOfBouncedEmail,
-      "bounce.bouncedEmailAddresses" -> bouncedAddresses.asJava
-    ), bounceSummary)
+      "bounce.mail.source" -> bounceNotification.senderOfBouncedEmail,
+      "bounce.bouncedEmailAddresses" -> bounceNotification.bouncedAddresses.asJava
+    ), bounceNotification.bounceSummary)
 
     if (bounce.isPermanent) {
-      Future.traverse(bouncedAddresses)(alertDeletion.deleteAllAlertsForEmailAddress)
-      if (bounce.isOnSuppressionList) {
-        val arn = sys.env("PermanentEmailBounceTopicArn")
-        logger.info(s"Sending an SNS alert to $arn")
-        Future(AWS.SNS.publish(PublishRequest.builder().message(bounceSummary).topicArn(arn).build()).get())
-      } else {
-        Future.successful(Unit)
-      }
-    } else {
-      Future.successful(Unit)
-    }
+      val deletionF = Future.traverse(bounceNotification.bouncedAddresses)(alertDeletion.deleteAllAlertsForEmailAddress)
+      val notificationF = alertDevsIfEmailWasSuppressed(bounceNotification)
+      for { _ <- deletionF; _ <- notificationF } yield ()
+    } else Future.successful(())
+  }
+
+  private def alertDevsIfEmailWasSuppressed(bounceNotification: BounceNotification): Future[_] = {
+    if (bounceNotification.bounce.isOnSuppressionList) {
+      val arn = sys.env("PermanentEmailBounceTopicArn")
+      logger.info(s"Sending an SNS alert to $arn")
+      Future(AWS.SNS.publish(PublishRequest.builder().message(bounceNotification.bounceSummary).topicArn(arn).build()).get())
+    } else Future.successful(())
   }
 
   /*
-   * Logic handler
-   */
-  def go(message: String): Unit = {
+     * Logic handler
+     */
+  def go(message: String): Future[_] = {
     logger.info(Map(
       "notification.message" -> message
     ), s"Running with notification message")
 
     Json.parse(message).validate[BounceNotification] match {
-      case JsSuccess(bounceNotification, _) => {
-        handleBounce(bounceNotification)
-      }
+      case JsSuccess(bounceNotification, _) => handleBounce(bounceNotification)
       case fail: JsError  =>
         logger.error(Map("notification.message" -> message),"Couldn't parse message as BounceNotification",fail)
+        Future.successful(())
     }
   }
 
@@ -63,7 +60,8 @@ object Lambda extends Logging {
    * Lambda's entry point
    */
   def handler(lambdaInput: SNSEvent, context: Context): Unit = {
-    lambdaInput.getRecords.asScala.map(_.getSNS.getMessage).toList.headOption foreach go
+    val rawBounceNotifications = lambdaInput.getRecords.asScala.map(_.getSNS.getMessage).toSeq
+    Await.ready(Future.traverse(rawBounceNotifications)(go), 30 seconds)
   }
 
 }

--- a/src/main/scala/housekeeper/Notification.scala
+++ b/src/main/scala/housekeeper/Notification.scala
@@ -3,7 +3,11 @@ package housekeeper
 import housekeeper.BounceNotification._
 import play.api.libs.json.{Json, Reads}
 
-case class BounceNotification(bounce: Bounce, mail: Mail)
+case class BounceNotification(bounce: Bounce, mail: Mail) {
+  val bouncedAddresses = bounce.bouncedEmailAddresses.toSeq.sorted
+  val senderOfBouncedEmail = mail.source
+  val bounceSummary = s"$senderOfBouncedEmail sent a ${bounce.bounceType} bounced message to ${bouncedAddresses.mkString(",")}"
+}
 
 object BounceNotification {
 

--- a/src/test/scala/housekeeper/AlertDeletionTest.scala
+++ b/src/test/scala/housekeeper/AlertDeletionTest.scala
@@ -1,19 +1,21 @@
 package housekeeper
 
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import housekeeper.Dynamo.OphanAlert
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scanamo.{LocalDynamoDB, Scanamo}
+import org.scanamo.{LocalDynamoDB, ScanamoAsync}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
-class AlertDeletionTest extends AnyFlatSpec with Matchers {
+class AlertDeletionTest extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
   lazy val client = LocalDynamoDB.client()
 
   "AlertDeletion" should "delete all the alerts for the specified email address" in {
-    val scanamo = Scanamo(client)
+    val scanamo = ScanamoAsync(client)
 
     val tableName = "TEST-ophan-alerts-"+Random.alphanumeric.take(5).mkString
     LocalDynamoDB.createTable(client)(tableName)("email" -> S, "alertName" -> S)
@@ -21,7 +23,7 @@ class AlertDeletionTest extends AnyFlatSpec with Matchers {
     val alertDeletion = new AlertDeletion(scanamo, tableName)
     val table = alertDeletion.table
 
-    def allAlerts(): Set[OphanAlert] = { scanamo.exec(table.scan()).flatMap(_.toOption).toSet }
+    def allAlerts(): Set[OphanAlert] = { scanamo.exec(table.scan()).futureValue.flatMap(_.toOption).toSet }
 
     val bouncingEmailAddress = "user.left@g.com"
     val alertsForBadEmail = (1 to 3).toSet[Int].map(n => OphanAlert(bouncingEmailAddress, s"Dead Alert $n"))

--- a/src/test/scala/housekeeper/AlertDeletionTest.scala
+++ b/src/test/scala/housekeeper/AlertDeletionTest.scala
@@ -34,9 +34,10 @@ class AlertDeletionTest extends AnyFlatSpec with Matchers with ScalaFutures with
 
     allAlerts() shouldBe (alertsForRemainingUsers ++ alertsForBadEmail)
 
-    alertDeletion.deleteAllAlertsForEmailAddress(bouncingEmailAddress)
+    whenReady(alertDeletion.deleteAllAlertsForEmailAddress(bouncingEmailAddress)) { _ =>
+      allAlerts() shouldBe alertsForRemainingUsers
+    }
 
-    allAlerts() shouldBe (alertsForRemainingUsers)
   }
 
 }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This upgrades the Scanamo and AWS dependencies ahead of moving to Scala 3. Some of the changes are fairly routine - e.g. changing to the new Amazon import path - others have been a bit trickier as we've discovered race conditions as we've standardised the code on AWS DynamoDB async access.

We've updated the tests and inner workings of the code itself to ensure concurrent futures are given time and space to complete.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

After deployment check [the ELK logs](https://logs.gutools.co.uk/s/ophan/goto/ef408780-64e7-11ed-91f7-07051e42dc36) and [email alerts dashboard](https://logs.gutools.co.uk/s/ophan/app/dashboards#/view/1f81e8b0-e68f-11e9-84ba-1710e629adf9?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d%2Fd,to:now))).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We're able to upgrade to Scala 3!

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Housekeeper stops working and we start sending bouncing emails, with AWS eventually taking away our right to send emails because we'll be seen as a spam service. Not great!