### PR TITLE
Fix AWS SdkClientException due to unspecified HTTP client

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,7 +3,6 @@ stacks:
 deployments:
   housekeeper:
     parameters:
-      bucket: ophan-dist
       fileName: housekeeper.jar
       functions:
         PROD:

--- a/src/main/scala/housekeeper/AWS.scala
+++ b/src/main/scala/housekeeper/AWS.scala
@@ -2,7 +2,9 @@ package housekeeper
 
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
+import software.amazon.awssdk.core.client.builder.SdkAsyncClientBuilder
 import software.amazon.awssdk.http.SdkHttpClient
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
@@ -18,8 +20,10 @@ object AWS {
   lazy val credentials: AwsCredentialsProvider =
     credentialsForDevAndProd("ophan", EnvironmentVariableCredentialsProvider.create())
 
-  def build[T, B <: AwsClientBuilder[B, T]](builder: B): T =
-    builder.credentialsProvider(credentials).region(region).build()
+  def build[T, B <: AwsClientBuilder[B, T] with SdkAsyncClientBuilder[B, T]](builder: B): T =
+    builder.credentialsProvider(credentials).region(region)
+      .httpClientBuilder(NettyNioAsyncHttpClient.builder()) // removing this causes failure after sbt-assembly
+      .build()
 
   val SNS = build[SnsAsyncClient, SnsAsyncClientBuilder](SnsAsyncClient.builder())
   val dynamoDb = build[DynamoDbAsyncClient, DynamoDbAsyncClientBuilder](DynamoDbAsyncClient.builder())

--- a/src/test/scala/housekeeper/AlertDeletionTest.scala
+++ b/src/test/scala/housekeeper/AlertDeletionTest.scala
@@ -6,13 +6,14 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scanamo.{LocalDynamoDB, ScanamoAsync}
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
 class AlertDeletionTest extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
-  lazy val client = LocalDynamoDB.client()
+  lazy val client: DynamoDbAsyncClient = LocalDynamoDB.client()
 
   "AlertDeletion" should "delete all the alerts for the specified email address" in {
     val scanamo = ScanamoAsync(client)


### PR DESCRIPTION
After https://github.com/guardian/ophan-housekeeper/pull/254, Housekeeper ran fine locally, but failed when running in the AWS Lambda environment, because sbt-assembly had thrown away `META-INF/services/software.amazon.awssdk.http.SdkHttpService`, which the AWS SDK uses to work out which HTTP client engine is available. We could try tweaking sbt-assembly's config, but it's probably better to be explicit in the client initialisation code. Note this is the approach we also take [in the main Ophan codebase](https://github.com/guardian/ophan/blob/80a84ee88dc5108dc3c5d1aa1bcf333ef32a6d55/aws/src/main/scala/ophan/aws/AWS.scala#L69).

https://github.com/guardian/ophan-housekeeper/pull/254#issuecomment-1317303239

https://github.com/aws/aws-sdk-java-v2/issues/446#issuecomment-500604983


Incidentally, triggering invocations of the AWS Lambda is a little fiddly because it expects to receive a big chunk of JSON detailing a bounced email, but thankfully there's a [reference example of that JSON in AWS docs](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-examples.html#event-publishing-retrieving-sns-bounce). So we can select the 'Publish message' button in [the `ses-email-bounce-notifications-for-housekeeper` topic of SNS](https://eu-west-1.console.aws.amazon.com/sns/v3/home?region=eu-west-1#/topic/arn:aws:sns:eu-west-1:021353022223:ses-email-bounce-notifications-for-housekeeper) to send a test SES message:

<img width="1851" alt="image" src="https://user-images.githubusercontent.com/11380557/202252405-9d8f451f-b16c-4b54-8b5b-d14bb43c1eee.png">

And we can see this working in [the ELK logs](https://logs.gutools.co.uk/s/ophan/goto/fb7d5300-65d4-11ed-b296-6f7175cb2b1c)!!

<img width="1851" alt="image" src="https://user-images.githubusercontent.com/11380557/202252509-a990e172-0cd8-4c4f-ba96-66e7c94c6a82.png">
