### PR TITLE
Upgrade to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,11 @@ description:= "Housekeeping for Ophan"
 
 version := "1.0"
 
-scalaVersion := "2.13.8"
+scalaVersion := "3.2.1"
 
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-target:jvm-1.8",
-  "-Ywarn-dead-code"
 )
 
 val scanamoVersion = "1.0.0-M23"

--- a/src/main/scala/housekeeper/AWS.scala
+++ b/src/main/scala/housekeeper/AWS.scala
@@ -1,6 +1,6 @@
 package housekeeper
 
-import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.auth.credentials.*
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
 import software.amazon.awssdk.core.client.builder.SdkAsyncClientBuilder
 import software.amazon.awssdk.http.SdkHttpClient

--- a/src/main/scala/housekeeper/AlertDeletion.scala
+++ b/src/main/scala/housekeeper/AlertDeletion.scala
@@ -1,12 +1,12 @@
 package housekeeper
 
-import concurrent.ExecutionContext.Implicits.global
-import cats.implicits._
+import cats.implicits.*
 import housekeeper.Dynamo.OphanAlert
-import org.scanamo._
-import org.scanamo.syntax._
-import org.scanamo.generic.auto._
+import org.scanamo.*
+import org.scanamo.generic.auto.*
+import org.scanamo.syntax.*
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object Dynamo extends Logging {

--- a/src/main/scala/housekeeper/Lambda.scala
+++ b/src/main/scala/housekeeper/Lambda.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.postfixOps
 
 object Lambda extends Logging {

--- a/src/main/scala/housekeeper/Logging.scala
+++ b/src/main/scala/housekeeper/Logging.scala
@@ -4,7 +4,7 @@ import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 trait Logging {
 

--- a/src/main/scala/housekeeper/Notification.scala
+++ b/src/main/scala/housekeeper/Notification.scala
@@ -1,6 +1,6 @@
 package housekeeper
 
-import housekeeper.BounceNotification._
+import housekeeper.BounceNotification.*
 import play.api.libs.json.{Json, Reads}
 
 case class BounceNotification(bounce: Bounce, mail: Mail) {

--- a/src/test/scala/housekeeper/AlertDeletionTest.scala
+++ b/src/test/scala/housekeeper/AlertDeletionTest.scala
@@ -1,12 +1,12 @@
 package housekeeper
 
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import housekeeper.Dynamo.OphanAlert
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scanamo.{LocalDynamoDB, ScanamoAsync}
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.*
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random


### PR DESCRIPTION
As described on tin, this follows on from the work of https://github.com/guardian/ophan-housekeeper/pull/254 and upgrades `ophan-housekeeper` to Scala 3!

In something of an anticlimax, this involved updating the version number and replacing a bunch of `_`s with `*`s. Still, Scala 3 is Scala 3, so hurrah!

