### PR TITLE
Changed Lambda name to the new Lambda AWS

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
       functions:
         PROD:
           filename: housekeeper.jar
-          name: Ophan-Housekeeper-Lambda-KBZN4AWWA0W7
+          name: Ophan-Housekeeper-housekeeper0B2EB566-ssGoZjafJE5p
     type: aws-lambda
 regions:
 - eu-west-1


### PR DESCRIPTION
## What does this change?

This PR is to change the name of Ophan Housekeeper Lambda in `riff-raff` file to match the new Lambda created in #265 

## How to test

We tested it by deploying it to PROD https://riffraff.gutools.co.uk/deployment/view/4f00d2fe-8d64-4b34-9bf2-59d5a00f6907

