### PR TITLE
Set netty as explicit dependency rather than dependency override

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,10 +26,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.10.0-RC7",
   "org.scanamo" %% "scanamo" % scanamoVersion,
   "org.scanamo" %% "scanamo-testkit" % scanamoVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.2.16" % Test
+  "org.scalatest" %% "scalatest" % "3.2.16" % Test,
+  "io.netty" % "netty-handler" % "4.1.118.Final"
 ) ++ Seq("dynamodb", "sns", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")
-
-dependencyOverrides += "io.netty" % "netty-handler" % "4.1.118.Final"
 
 enablePlugins(BuildInfoPlugin)
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Roberto [pointed out](https://github.com/guardian/maintaining-scala-projects/issues/20) that setting an explicit dependency is preferable to using a dependency override. SBT will use only the latest version of any sub-dependency, and the override will stop this happening. This PR sets `netty-handler` as a standard dependency for this reason.