### PR TITLE
Bump aws sdk package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "org.scanamo" %% "scanamo-testkit" % scanamoVersion % Test,
   "org.scalatest" %% "scalatest" % "3.2.16" % Test,
   "io.netty" % "netty-handler" % "4.1.118.Final"
-) ++ Seq("dynamodb", "sns", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")
+) ++ Seq("dynamodb", "sns", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.32.29")
 
 enablePlugins(BuildInfoPlugin)
 


### PR DESCRIPTION
## What does this change?
- Bumps aws sdk package to latest version

## Why are we doing this?
- There is a security vulnerability with older versions (<= 4.1.123.Final) of netty-codec-http2, which is a downstream dependency of the aws sdk

## Testing
**netty-codec-http2 version is >4.1.123.Final:**
- Ran `sbt` then `whatDependsOn io.netty netty-codec-http`
- Before the dependency tree listed  `io.netty:netty-codec-http:4.1.108.Final` afterwards it was `io.netty:netty-codec-http2:4.1.124.Final`

**Project still builds:**
- Ran `sbt compile` received output `[success] Total time: 2 s, completed 26 Aug 2025, 16:12:36`


**Housekeeper still works:**
- Went to https://dashboard.ophan.co.uk/alerts and setup a new alert for myself 
- Added myself as a bounce recipient in `src/test/resources/notificationMessages/permanentBounce.ophanAlert.json`
- Ran `sbt` then `run src/test/resources/notificationMessages/permanentBounce.ophanAlert.json`
- Went back to the `alerts` page an checked that my new alert had been deleted
